### PR TITLE
Remove .precomp in all dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *~
 *.swp
 *.swo
-lib/.precomp
+.precomp


### PR DESCRIPTION
Some [recomp files](https://github.com/ijneb/telegram-bot/tree/master/.precomp/29491C244F91A844371BF302D3C3B7DC55016DE4/C7) appear to have made it into the repo. This PR makes git ignore `.precomp` in all directories.

You'll also need to run 

```
git rm --cached .precomp
```

to remove the already-tracked dir in the repo.